### PR TITLE
Remove unused require of renamed module

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,6 @@
 // E.g. node app.js http://localhost:8080/cc.xml 4444
 
 var http    = require('http'),
-    sys     = require('sys'),
     url     = require('url'),
     sax     = require('sax'),
     express = require('express'),


### PR DESCRIPTION
Running on Node.js > 0.3.0 said:

```
The "sys" module is now called "util". It should have a similar interface.
```

But sys was not being used anyway, so it can be deleted.
